### PR TITLE
Fix #8: resolve ALA image redirects to the direct file for Commons upload

### DIFF
--- a/tarsier/imagedetails.html
+++ b/tarsier/imagedetails.html
@@ -28,6 +28,7 @@
   </style>
   <script src="js/commons-domains.js"></script>
   <script src="js/commons-dup.js"></script>
+  <script src="js/ala.js"></script>
 </head>
 <body>
   <main class="container">
@@ -239,15 +240,33 @@
 
     // The hosting-organization title is needed for the institution template; fetch it if we
     // have a key, otherwise fall back to dataset/institution fields already on the occurrence.
-    var orgKey = occ.hostingOrganizationKey || occ.publishingOrgKey;
-    if (orgKey) {
-      fetch(API + "/organization/" + orgKey, { headers: { Accept: "application/json" } })
-        .then(function (r) { return r.ok ? r.json() : null; })
-        .then(function (o) { render(o && o.title); })
-        .catch(function () { render(null); });
-    } else {
-      render(null);
+    function proceed() {
+      var orgKey = occ.hostingOrganizationKey || occ.publishingOrgKey;
+      if (orgKey) {
+        fetch(API + "/organization/" + orgKey, { headers: { Accept: "application/json" } })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (o) { render(o && o.title); })
+          .catch(function () { render(null); });
+      } else {
+        render(null);
+      }
     }
+
+    // ALA images come from GBIF as a redirecting proxy/thumbnail URL. Resolve it to the direct
+    // full-size file (which Commons can fetch without following a redirect) and use ALA's
+    // license/attribution where GBIF's is missing, before rendering. No-op for non-ALA images.
+    (window.AlaImages ? AlaImages.resolve(media.identifier) : Promise.resolve(null))
+      .then(function (ala) {
+        if (ala) {
+          media.identifier = ala.url;
+          if (ala.mimeType) media.format = ala.mimeType;
+          if (!media.license && ala.license) media.license = ala.license;
+          if (!occ.rightsHolder && ala.rightsHolder) occ.rightsHolder = ala.rightsHolder;
+          if (!occ.recordedBy && ala.creator) occ.recordedBy = ala.creator;
+        }
+      })
+      .catch(function () {})
+      .then(proceed);
   })();
   </script>
 </body>

--- a/tarsier/js/ala.js
+++ b/tarsier/js/ala.js
@@ -1,0 +1,33 @@
+/* Atlas of Living Australia images: GBIF hands out a redirecting proxy/thumbnail URL on
+ * images.ala.org.au. Commons upload-by-URL does not follow redirects, so resolve the image id
+ * to the canonical full-size file on the direct storage host (and pull ALA's license/attribution,
+ * which is often richer than GBIF's) via ALA's CORS-enabled image API. */
+(function (global) {
+  "use strict";
+  var WS = "https://images.ala.org.au/ws/image/";
+  var STORE_HOST = "images-assets.ala.org.au"; // direct, non-redirecting storage host
+
+  function imageId(url) {
+    if (!/\.ala\.org\.au/i.test(url || "")) return null;
+    var m = String(url).match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+    return m ? m[0] : null;
+  }
+
+  // Resolve to { url, license, creator, rightsHolder, title, mimeType } or null if not an ALA image.
+  function resolve(url) {
+    var id = imageId(url);
+    if (!id) return Promise.resolve(null);
+    return fetch(WS + id, { headers: { Accept: "application/json" } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) {
+        if (!d || !d.imageUrl) return null;
+        var direct = d.imageUrl.replace(/:\/\/images\.ala\.org\.au\//i, "://" + STORE_HOST + "/");
+        var lic = (d.recognisedLicence && d.recognisedLicence.url) || d.license || "";
+        return { url: direct, license: lic, creator: d.creator || "",
+                 rightsHolder: d.rightsHolder || "", title: d.title || "", mimeType: d.mimeType || "" };
+      })
+      .catch(function () { return null; });
+  }
+
+  global.AlaImages = { resolve: resolve, imageId: imageId };
+})(window);


### PR DESCRIPTION
Fixes #8.

GBIF serves Atlas of Living Australia (ALA) images as a **redirecting proxy/thumbnail URL** on `images.ala.org.au` (e.g. `…/image/proxyImageThumbnailLarge?imageId=…`). Commons upload-by-URL does **not** follow redirects, so these uploads failed.

## Fix
- **`js/ala.js`** — resolve an ALA image id to its canonical full-size file on the direct storage host (`images-assets.ala.org.au/store/.../original`) via ALA's CORS-enabled `ws/image/{id}` API, which also returns license / creator / rightsHolder.
- **`imagedetails.html`** — before rendering, resolve ALA images and use the direct URL for the preview, the source-host allow-list check, and the Commons `wpUploadFileURL`; fill license/attribution from ALA when GBIF has none.

## Verified
- A GBIF ALA proxy URL resolves to `images-assets.ala.org.au/store/.../original` (full-size, no redirect).
- An ALA image with a CC-BY license (GBIF had none; record was CC-BY-NC) becomes reusable, with the direct file as `wpUploadFileURL` and `wpLicense=cc-by-4.0`.
- An ALA image with no license anywhere correctly falls back to the record license (no false upload).

## Heads-up for the maintainer
The ALA host currently on the Commons allow-list — `ala-images.s3.ap-southeast-2.amazonaws.com` — is **stale** (it 404s for current `/store/` paths). The live host is `images-assets.ala.org.au`, which is **not** allow-listed. The domain-check now flags this accurately and offers the proposal flow, but uploads won't fully succeed until `images-assets.ala.org.au` is added to [the Commons allow-list](https://commons.wikimedia.org/wiki/MediaWiki:Copyupload-allowed-domains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)