### PR TITLE
Retry GBIF on HTTP 429/503 instead of failing the search

### DIFF
--- a/tarsier/index.html
+++ b/tarsier/index.html
@@ -201,9 +201,19 @@
       });
     }
 
-    function getJSON(url) {
+    // GET JSON with automatic retry/backoff on rate-limiting (429) and transient 503s, so a
+    // burst of GBIF calls in one search rides out a throttle instead of failing.
+    function getJSON(url, attempt) {
+      attempt = attempt || 0;
       return fetch(url, { headers: { Accept: "application/json" } }).then(function (r) {
-        if (!r.ok) throw new Error("GBIF returned HTTP " + r.status);
+        if ((r.status === 429 || r.status === 503) && attempt < 4) {
+          var ra = parseInt(r.headers.get("Retry-After"), 10);
+          var wait = (ra > 0 ? ra * 1000 : 600 * Math.pow(2, attempt)); // ~0.6s, 1.2s, 2.4s, 4.8s
+          return new Promise(function (res) { setTimeout(res, wait); })
+            .then(function () { return getJSON(url, attempt + 1); });
+        }
+        if (r.status === 429) throw new Error("rate-limited (HTTP 429) — please retry in a moment");
+        if (!r.ok) throw new Error("the data service returned HTTP " + r.status);
         return r.json();
       });
     }


### PR DESCRIPTION
Fixes the "Something went wrong talking to GBIF: GBIF returned HTTP 429" error.

A single Tarsier search fires several GBIF requests in quick succession — `species/match`, the license facet, the first results page, the background image-level scan, and per-dataset title lookups — which can trip GBIF's rate limit and fail the whole search.

`getJSON` now **retries 429/503 up to 4 times with exponential backoff** (~0.6s → 1.2s → 2.4s → 4.8s, honoring a `Retry-After` header when present), so a transient throttle rides out instead of erroring. If it's still limited after retries, the message is friendlier ("rate-limited — please retry in a moment"). Also de-hardcodes "GBIF" from the generic HTTP-error string (the same helper is reused for Wikidata and Zenodo).

**Verified:** the taxon from the report (*Pinalia graminifolia*) now loads (39 images), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)